### PR TITLE
Send logs and metrics to SigNoz

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,38 @@
 # INFO8985_monolith
 otel for a python monolithic app
 
+## SigNoz Setup
+
+This project can export traces, metrics and logs directly to [SigNoz](https://github.com/SigNoz/signoz).
+Clone the SigNoz repo as a submodule and start its Docker compose stack:
+
+```bash
+git submodule add https://github.com/SigNoz/signoz.git signoz
+cd signoz/deploy/docker/clickhouse-setup
+docker compose up -d
+cd ../../..
+```
+
+If the repository was cloned without submodules, initialise them with:
+
+```bash
+git submodule update --init --recursive
+```
+
+The application expects the OTLP endpoint to be available at `http://localhost:4317`.
+Exporters will read this from the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable.
+
 ```bash
 ansible-playbook up.yml
 ```
 
 This is based on [the open telemetry docs](https://opentelemetry.io/docs/languages/python/getting-started/)
 
-run `docker-compose up`. In another terminal window run:
+Run the OpenTelemetry collector and SigNoz stack using `docker compose up -d`. In another terminal window start the application:
 
 ```bash
 export OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 opentelemetry-instrument --logs_exporter otlp flask run -p 8080
 ```
 or for tracing, metric monitoring and logging
@@ -18,6 +40,7 @@ or for tracing, metric monitoring and logging
 
 ```bash
 export OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
-opentelemetry-instrument --logs_exporter otlp --metrics_exporter otlp --traces_exporter otlp --service_name your-service-name flask run -p 8081
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+opentelemetry-instrument --logs_exporter otlp --metrics_exporter otlp --traces_exporter otlp --service_name dice-service flask run -p 8081
 ```
 

--- a/app.py
+++ b/app.py
@@ -1,10 +1,50 @@
 # These are the necessary import declarations
-from opentelemetry import trace
-from opentelemetry import metrics
+import os
+from opentelemetry import trace, metrics, logs
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, OTLPSpanExporter
+from opentelemetry.sdk.metrics.export import (
+    PeriodicExportingMetricReader,
+    OTLPMetricExporter,
+)
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor, OTLPLogExporter
 
 from random import randint
 from flask import Flask, request
 import logging
+
+# Setup OpenTelemetry providers and exporters for SigNoz
+resource = Resource(attributes={SERVICE_NAME: "dice-service"})
+
+trace_provider = TracerProvider(resource=resource)
+span_exporter = OTLPSpanExporter(
+    endpoint=os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317"),
+    insecure=True,
+)
+trace_provider.add_span_processor(BatchSpanProcessor(span_exporter))
+trace.set_tracer_provider(trace_provider)
+
+metric_exporter = OTLPMetricExporter(
+    endpoint=os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317"),
+    insecure=True,
+)
+metric_reader = PeriodicExportingMetricReader(metric_exporter)
+meter_provider = MeterProvider(resource=resource, metric_readers=[metric_reader])
+metrics.set_meter_provider(meter_provider)
+
+log_exporter = OTLPLogExporter(
+    endpoint=os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317"),
+    insecure=True,
+)
+log_provider = LoggerProvider(resource=resource)
+log_provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter))
+logs.set_logger_provider(log_provider)
+logging.getLogger().addHandler(
+    LoggingHandler(level=logging.INFO, logger_provider=log_provider)
+)
 
 # Acquire a tracer
 tracer = trace.get_tracer("diceroller.tracer")
@@ -26,15 +66,22 @@ def roll_dice():
     # This creates a new span that's the child of the current one
     with tracer.start_as_current_span("roll") as roll_span:
         player = request.args.get('player', default = None, type = str)
-        result = str(roll())
+        try:
+            result = str(roll())
+        except Exception:
+            logger.exception("roll failed")
+            raise
         roll_span.set_attribute("roll.value", result)
         # This adds 1 to the counter for the given roll value
         roll_counter.add(1, {"roll.value": result})
         if player:
-            logger.warn("{} is rolling the dice: {}", player, result)
+            logger.warning("%s is rolling the dice: %s", player, result)
         else:
-            logger.warn("Anonymous player is rolling the dice: %s", result)
+            logger.warning("Anonymous player is rolling the dice: %s", result)
         return result
 
 def roll():
-    return randint(1, 6)
+    result = randint(1, 6)
+    if result == 6:
+        raise RuntimeError("something broke while rolling the dice")
+    return result

--- a/otel-collector-config.yaml
+++ b/otel-collector-config.yaml
@@ -7,22 +7,23 @@ receivers:
       http:
         endpoint: 0.0.0.0:4318
 exporters:
-  # NOTE: Prior to v0.86.0 use `logging` instead of `debug`.
-  debug:
-    verbosity: detailed
+  otlp:
+    endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:localhost:4317}
+    tls:
+      insecure: true
 processors:
   batch:
 service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [debug]
+      exporters: [otlp]
       processors: [batch]
     metrics:
       receivers: [otlp]
-      exporters: [debug]
+      exporters: [otlp]
       processors: [batch]
     logs:
       receivers: [otlp]
-      exporters: [debug]
+      exporters: [otlp]
       processors: [batch]


### PR DESCRIPTION
## Summary
- send traces, metrics and logs to SigNoz collector
- raise an error when a dice roll equals 6 and log it
- update OTEL collector config to forward data to SigNoz
- document how to run the stack via SigNoz submodule

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684bfaf75d5c83338a9951448f9168f4